### PR TITLE
Add reset button with confirmation dialog

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,13 @@ const DEFAULT_CONFIG = {
 export default function App() {
   const disk = useDiskState(DEFAULT_CONFIG);
   const [editIdx, setEditIdx] = useState(null);
+  const [confirmReset, setConfirmReset] = useState(false);
+
+  const handleReset = () => {
+    disk.reset();
+    setEditIdx(null);
+    setConfirmReset(false);
+  };
 
   const handleEdit = (i) => setEditIdx(i);
 
@@ -41,18 +48,52 @@ export default function App() {
     <div className="min-h-screen bg-disk-bg p-6 md:px-4">
       {/* Header */}
       <div className="max-w-[900px] mx-auto mb-7">
-        <div className="flex items-center gap-2.5 mb-1">
-          <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-gradient-to-br from-blue-500 to-violet-500 text-base">
-            ◫
+        <div className="flex items-center justify-between mb-1">
+          <div className="flex items-center gap-2.5">
+            <div className="w-8 h-8 rounded-lg flex items-center justify-center bg-gradient-to-br from-blue-500 to-violet-500 text-base">
+              ◫
+            </div>
+            <h1 className="m-0 text-[22px] font-display font-bold text-slate-50 tracking-tight">
+              Disk Partition Visualizer
+            </h1>
           </div>
-          <h1 className="m-0 text-[22px] font-display font-bold text-slate-50 tracking-tight">
-            Disk Partition Visualizer
-          </h1>
+          <button
+            onClick={() => setConfirmReset(true)}
+            className="text-[11px] font-mono px-3 py-1.5 rounded-md border border-red-800 text-red-400 hover:bg-red-900/30 transition-colors"
+          >
+            Reset
+          </button>
         </div>
         <p className="m-0 text-[11px] text-slate-500 ml-[42px] font-mono">
           Interactive block-level partition layout · LBA addressing · Overlap detection
         </p>
       </div>
+
+      {/* Reset confirmation dialog */}
+      {confirmReset && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <div className="bg-disk-surface border border-disk-border rounded-xl p-6 max-w-sm w-full mx-4 shadow-xl">
+            <h2 className="text-slate-100 font-semibold text-base mb-2">Reset all data?</h2>
+            <p className="text-slate-400 text-[13px] mb-5">
+              This will clear all partitions and restore the default disk configuration.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setConfirmReset(false)}
+                className="text-[12px] font-mono px-4 py-1.5 rounded-md border border-disk-border text-slate-400 hover:bg-white/5 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleReset}
+                className="text-[12px] font-mono px-4 py-1.5 rounded-md bg-red-600 hover:bg-red-700 text-white transition-colors"
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       <div className="max-w-[900px] mx-auto">
         {/* Disk configuration */}

--- a/src/hooks/useDiskState.js
+++ b/src/hooks/useDiskState.js
@@ -96,6 +96,14 @@ export default function useDiskState(initialConfig = {}) {
     setPartitions(preset.partitions);
   }, []);
 
+  const reset = useCallback(() => {
+    setDiskSizeValue(initDiskSize);
+    setDiskSizeUnit(initDiskUnit);
+    setSectorSize(initSectorSize);
+    setPartitions(initPartitions);
+    try { localStorage.removeItem(STORAGE_KEY); } catch {}
+  }, [initDiskSize, initDiskUnit, initSectorSize, initPartitions]);
+
   return {
     // Config state + setters
     diskSizeValue,
@@ -121,5 +129,6 @@ export default function useDiskState(initialConfig = {}) {
     updatePartition,
     removePartition,
     loadPreset,
+    reset,
   };
 }

--- a/src/test/useDiskState.test.jsx
+++ b/src/test/useDiskState.test.jsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, render, screen, fireEvent } from '@testing-library/react';
+import useDiskState from '../hooks/useDiskState';
+import App from '../App';
+
+const STORAGE_KEY = 'diskPartitionState';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useDiskState — localStorage persistence', () => {
+  it('loads defaults when localStorage is empty', () => {
+    const { result } = renderHook(() => useDiskState());
+    expect(result.current.diskSizeValue).toBe('500');
+    expect(result.current.diskSizeUnit).toBe('GB');
+    expect(result.current.sectorSize).toBe(512);
+    expect(result.current.partitions).toEqual([]);
+  });
+
+  it('saves state to localStorage when values change', () => {
+    const { result } = renderHook(() => useDiskState());
+
+    act(() => {
+      result.current.setDiskSizeValue('1000');
+    });
+
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(saved.diskSizeValue).toBe('1000');
+  });
+
+  it('restores state from localStorage on init', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        diskSizeValue: '256',
+        diskSizeUnit: 'MB',
+        sectorSize: 4096,
+        partitions: [{ name: 'boot', startBlock: 0, endBlock: 100 }],
+      })
+    );
+
+    const { result } = renderHook(() => useDiskState());
+    expect(result.current.diskSizeValue).toBe('256');
+    expect(result.current.diskSizeUnit).toBe('MB');
+    expect(result.current.sectorSize).toBe(4096);
+    expect(result.current.partitions).toHaveLength(1);
+    expect(result.current.partitions[0].name).toBe('boot');
+  });
+
+  it('falls back to defaults when localStorage contains invalid JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-valid-json');
+    const { result } = renderHook(() => useDiskState());
+    expect(result.current.diskSizeValue).toBe('500');
+    expect(result.current.partitions).toEqual([]);
+  });
+
+  it('persists partition additions', () => {
+    const { result } = renderHook(() => useDiskState());
+    const partition = { name: 'data', startBlock: 0, endBlock: 200 };
+
+    act(() => {
+      result.current.addPartition(partition);
+    });
+
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(saved.partitions).toHaveLength(1);
+    expect(saved.partitions[0].name).toBe('data');
+  });
+});
+
+describe('useDiskState — reset', () => {
+  it('restores default values after reset', () => {
+    const { result } = renderHook(() =>
+      useDiskState({ diskSize: '500', diskUnit: 'GB', sectorSize: 512, partitions: [] })
+    );
+
+    act(() => {
+      result.current.addPartition({ name: 'tmp', startBlock: 0, endBlock: 100 });
+      result.current.setDiskSizeValue('1000');
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.diskSizeValue).toBe('500');
+    expect(result.current.diskSizeUnit).toBe('GB');
+    expect(result.current.sectorSize).toBe(512);
+    expect(result.current.partitions).toEqual([]);
+  });
+
+  it('clears localStorage on reset', () => {
+    const { result } = renderHook(() => useDiskState());
+
+    act(() => {
+      result.current.addPartition({ name: 'tmp', startBlock: 0, endBlock: 100 });
+    });
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)).partitions).toHaveLength(1);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)).partitions).toEqual([]);
+  });
+});
+
+describe('Reset button UI', () => {
+  it('shows a Reset button', () => {
+    render(<App />);
+    expect(screen.getByRole('button', { name: /reset/i })).toBeInTheDocument();
+  });
+
+  it('opens a confirmation dialog when Reset is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /^reset$/i }));
+    expect(screen.getByText(/reset all data/i)).toBeInTheDocument();
+  });
+
+  it('closes dialog without resetting when Cancel is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /^reset$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByText(/reset all data/i)).not.toBeInTheDocument();
+  });
+
+  it('resets data and closes dialog when Reset is confirmed', () => {
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /^reset$/i }));
+    const confirmBtn = screen.getAllByRole('button', { name: /^reset$/i }).at(-1);
+    fireEvent.click(confirmBtn);
+    expect(screen.queryByText(/reset all data/i)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `reset()` action to `useDiskState` that restores all state to defaults and clears localStorage
- Adds a **Reset** button in the app header
- Clicking Reset shows a confirmation dialog to prevent accidental data loss
- Confirming clears all partitions and restores the default disk config

## Tests

- `reset()` restores default values
- `reset()` clears persisted partitions from localStorage
- Reset button is visible in the UI
- Clicking Reset opens the confirmation dialog
- Cancel closes the dialog without resetting
- Confirming resets data and closes the dialog

All 33 tests pass.

Closes #2