### PR TITLE
Make Total Blocks (LBA) field editable with two-way sync

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,6 +105,7 @@ export default function App() {
           sectorSize={disk.sectorSize}
           setSectorSize={disk.setSectorSize}
           totalBlocks={disk.totalBlocks}
+          setTotalBlocks={disk.setTotalBlocks}
           diskBytes={disk.diskBytes}
           allocatedBlocks={disk.allocatedBlocks}
           freeBlocks={disk.freeBlocks}

--- a/src/components/DiskConfig.jsx
+++ b/src/components/DiskConfig.jsx
@@ -11,6 +11,7 @@ export default function DiskConfig({
   sectorSize,
   setSectorSize,
   totalBlocks,
+  setTotalBlocks,
   diskBytes,
   allocatedBlocks,
   freeBlocks,
@@ -66,10 +67,13 @@ export default function DiskConfig({
 
         {/* Total blocks */}
         <div>
-          <div className={labelCls}>Total Blocks</div>
-          <div className="bg-[#0F172A] rounded-[5px] px-2.5 py-2 border border-disk-border font-mono text-[13px] font-bold text-blue-500 tracking-wide">
-            {totalBlocks.toLocaleString()}
-          </div>
+          <div className={labelCls}>Total Blocks (LBA)</div>
+          <input
+            value={totalBlocks}
+            onChange={(e) => setTotalBlocks(e.target.value)}
+            className={inputCls + ' font-bold text-blue-400'}
+            placeholder="0"
+          />
         </div>
       </div>
 

--- a/src/hooks/useDiskState.js
+++ b/src/hooks/useDiskState.js
@@ -96,6 +96,14 @@ export default function useDiskState(initialConfig = {}) {
     setPartitions(preset.partitions);
   }, []);
 
+  const setTotalBlocks = useCallback((blocks) => {
+    const parsed = parseInt(blocks);
+    if (isNaN(parsed) || parsed < 0) return;
+    const newBytes = parsed * sectorSize;
+    const unitMultiplier = SIZE_UNITS[diskSizeUnit] || 1;
+    setDiskSizeValue(String(newBytes / unitMultiplier));
+  }, [sectorSize, diskSizeUnit]);
+
   const reset = useCallback(() => {
     setDiskSizeValue(initDiskSize);
     setDiskSizeUnit(initDiskUnit);
@@ -129,6 +137,7 @@ export default function useDiskState(initialConfig = {}) {
     updatePartition,
     removePartition,
     loadPreset,
+    setTotalBlocks,
     reset,
   };
 }

--- a/src/test/useDiskState.test.jsx
+++ b/src/test/useDiskState.test.jsx
@@ -107,6 +107,46 @@ describe('useDiskState — reset', () => {
   });
 });
 
+describe('useDiskState — setTotalBlocks', () => {
+  it('updates diskSizeValue when total blocks are set', () => {
+    const { result } = renderHook(() =>
+      useDiskState({ diskSize: '500', diskUnit: 'GB', sectorSize: 512, partitions: [] })
+    );
+
+    act(() => {
+      // 500 GB / 512 B = 976,562,500 blocks → set to 1,000,000 blocks
+      // expected diskSizeValue = (1_000_000 * 512) / 1e9 = 0.512 GB
+      result.current.setTotalBlocks(1_000_000);
+    });
+
+    expect(result.current.diskSizeValue).toBe('0.512');
+    expect(result.current.totalBlocks).toBe(1_000_000);
+  });
+
+  it('does nothing for invalid input', () => {
+    const { result } = renderHook(() =>
+      useDiskState({ diskSize: '500', diskUnit: 'GB', sectorSize: 512, partitions: [] })
+    );
+    const before = result.current.diskSizeValue;
+
+    act(() => { result.current.setTotalBlocks('abc'); });
+    expect(result.current.diskSizeValue).toBe(before);
+
+    act(() => { result.current.setTotalBlocks(-1); });
+    expect(result.current.diskSizeValue).toBe(before);
+  });
+
+  it('keeps two-way sync: disk size change updates totalBlocks', () => {
+    const { result } = renderHook(() =>
+      useDiskState({ diskSize: '1', diskUnit: 'GB', sectorSize: 512, partitions: [] })
+    );
+
+    act(() => { result.current.setDiskSizeValue('2'); });
+    // 2 GB / 512 B = 3,906,250 blocks
+    expect(result.current.totalBlocks).toBe(3_906_250);
+  });
+});
+
 describe('Reset button UI', () => {
   it('shows a Reset button', () => {
     render(<App />);


### PR DESCRIPTION
## Summary

- The **Total Blocks** field in Disk Configuration is now an editable input instead of a read-only display
- Editing **Disk Size** → Total Blocks updates automatically (existing behavior)
- Editing **Total Blocks** → Disk Size updates automatically (new)
- Invalid input (non-numeric, negative) is silently ignored

## Changes

- `useDiskState.js` — added `setTotalBlocks(blocks)` that back-calculates `diskSizeValue = (blocks * sectorSize) / unitMultiplier`
- `DiskConfig.jsx` — Total Blocks div replaced with an editable input; accepts `setTotalBlocks` prop
- `App.jsx` — passes `setTotalBlocks` down to `DiskConfig`

## Tests (3 new)

- Setting total blocks updates `diskSizeValue` correctly
- Invalid input (NaN, negative) is ignored
- Changing disk size still updates `totalBlocks` (two-way sync regression check)

All 36 tests pass.

Closes #5