### PR TITLE
Auto-select best unit when editing Total Blocks to avoid scientific notation

### DIFF
--- a/src/hooks/useDiskState.js
+++ b/src/hooks/useDiskState.js
@@ -100,9 +100,17 @@ export default function useDiskState(initialConfig = {}) {
     const parsed = parseInt(blocks);
     if (isNaN(parsed) || parsed < 0) return;
     const newBytes = parsed * sectorSize;
-    const unitMultiplier = SIZE_UNITS[diskSizeUnit] || 1;
-    setDiskSizeValue(String(newBytes / unitMultiplier));
-  }, [sectorSize, diskSizeUnit]);
+    const units = [
+      { label: 'TB', value: SIZE_UNITS.TB },
+      { label: 'GB', value: SIZE_UNITS.GB },
+      { label: 'MB', value: SIZE_UNITS.MB },
+      { label: 'KB', value: SIZE_UNITS.KB },
+      { label: 'B',  value: SIZE_UNITS.B  },
+    ];
+    const best = units.find((u) => newBytes >= u.value) || units[units.length - 1];
+    setDiskSizeUnit(best.label);
+    setDiskSizeValue(String(newBytes / best.value));
+  }, [sectorSize]);
 
   const reset = useCallback(() => {
     setDiskSizeValue(initDiskSize);

--- a/src/test/useDiskState.test.jsx
+++ b/src/test/useDiskState.test.jsx
@@ -108,19 +108,33 @@ describe('useDiskState — reset', () => {
 });
 
 describe('useDiskState — setTotalBlocks', () => {
-  it('updates diskSizeValue when total blocks are set', () => {
+  it('updates diskSizeValue and auto-selects the best unit', () => {
     const { result } = renderHook(() =>
       useDiskState({ diskSize: '500', diskUnit: 'GB', sectorSize: 512, partitions: [] })
     );
 
     act(() => {
-      // 500 GB / 512 B = 976,562,500 blocks → set to 1,000,000 blocks
-      // expected diskSizeValue = (1_000_000 * 512) / 1e9 = 0.512 GB
+      // 1,000,000 blocks * 512 B = 512,000,000 B = 512 MB
       result.current.setTotalBlocks(1_000_000);
     });
 
-    expect(result.current.diskSizeValue).toBe('0.512');
+    expect(result.current.diskSizeUnit).toBe('MB');
+    expect(result.current.diskSizeValue).toBe('512');
     expect(result.current.totalBlocks).toBe(1_000_000);
+  });
+
+  it('uses B unit for very small block counts', () => {
+    const { result } = renderHook(() =>
+      useDiskState({ diskSize: '500', diskUnit: 'GB', sectorSize: 512, partitions: [] })
+    );
+
+    act(() => {
+      // 1 block * 512 B = 512 B
+      result.current.setTotalBlocks(1);
+    });
+
+    expect(result.current.diskSizeUnit).toBe('B');
+    expect(result.current.diskSizeValue).toBe('512');
   });
 
   it('does nothing for invalid input', () => {


### PR DESCRIPTION
## Problem

Typing a small value in Total Blocks (e.g. `1`) kept the current unit (GB), producing unreadable values like `5.12e-7 GB`.

## Fix

`setTotalBlocks` now picks the most appropriate unit (TB → GB → MB → KB → B) based on the resulting byte count, so `1 block × 512B` displays as `512 B` instead of `5.12e-7 GB`.

## Tests

- Added test: `1 block * 512B` → `512 B`
- Updated existing test: `1,000,000 blocks * 512B` → `512 MB` (was checking for `0.512 GB`)

Closes #13