### PR TITLE
Add custom user presets (save, load, delete)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import useDiskState from './hooks/useDiskState';
+import useCustomPresets from './hooks/useCustomPresets';
 import {
   PieChart,
   DiskBar,
@@ -23,8 +24,10 @@ const DEFAULT_CONFIG = {
 
 export default function App() {
   const disk = useDiskState(DEFAULT_CONFIG);
+  const { customPresets, savePreset, deletePreset } = useCustomPresets();
   const [editIdx, setEditIdx] = useState(null);
   const [confirmReset, setConfirmReset] = useState(false);
+  const [savePresetName, setSavePresetName] = useState(null);
 
   const handleReset = () => {
     disk.reset();
@@ -42,6 +45,19 @@ export default function App() {
   const handleLoadPreset = (preset) => {
     disk.loadPreset(preset);
     setEditIdx(null);
+  };
+
+  const handleSavePreset = () => setSavePresetName('');
+
+  const handleConfirmSavePreset = () => {
+    if (!savePresetName.trim()) return;
+    savePreset(savePresetName.trim(), {
+      diskSizeValue: disk.diskSizeValue,
+      diskSizeUnit: disk.diskSizeUnit,
+      sectorSize: disk.sectorSize,
+      partitions: disk.partitions,
+    });
+    setSavePresetName(null);
   };
 
   return (
@@ -89,6 +105,38 @@ export default function App() {
                 className="text-[13px] px-4 py-1.5 rounded-lg bg-[#ff453a] hover:bg-[#ff6961] text-white transition-colors font-medium"
               >
                 Reset
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Save preset modal */}
+      {savePresetName !== null && (
+        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+          <div className="bg-disk-surface border border-disk-border rounded-xl p-6 max-w-sm w-full mx-4 shadow-xl">
+            <h2 className="text-slate-100 font-semibold text-base mb-2">Save preset</h2>
+            <input
+              autoFocus
+              value={savePresetName}
+              onChange={(e) => setSavePresetName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleConfirmSavePreset(); if (e.key === 'Escape') setSavePresetName(null); }}
+              placeholder="Preset name"
+              className="w-full bg-[#0F172A] border border-slate-700 rounded-[5px] px-3 py-2 text-slate-200 font-mono text-xs outline-none focus:border-blue-500 mb-4"
+            />
+            <div className="flex gap-3 justify-end">
+              <button
+                onClick={() => setSavePresetName(null)}
+                className="text-[12px] font-mono px-4 py-1.5 rounded-md border border-disk-border text-slate-400 hover:bg-white/5 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmSavePreset}
+                disabled={!savePresetName.trim()}
+                className="text-[12px] font-mono px-4 py-1.5 rounded-md bg-blue-600 hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors"
+              >
+                Save
               </button>
             </div>
           </div>
@@ -154,7 +202,12 @@ export default function App() {
           setEditIdx={setEditIdx}
         />
 
-        <PresetBar onLoad={handleLoadPreset} />
+        <PresetBar
+          onLoad={handleLoadPreset}
+          customPresets={customPresets}
+          onSave={handleSavePreset}
+          onDelete={deletePreset}
+        />
 
         <div className="text-center mt-6 text-[10px] text-[#3a3a3c]">
           Built by Amol · Disk Partition Visualizer

--- a/src/components/PresetBar.jsx
+++ b/src/components/PresetBar.jsx
@@ -1,19 +1,75 @@
+import { useState } from 'react';
 import PRESETS from '../presets';
 
-export default function PresetBar({ onLoad }) {
+export default function PresetBar({ onLoad, customPresets, onSave, onDelete }) {
+  const [confirmDeleteId, setConfirmDeleteId] = useState(null);
+
+  const btnCls = 'bg-disk-surface border border-disk-border rounded-lg text-[#8e8e9d] px-3 py-1.5 cursor-pointer text-[11px] font-medium transition-all hover:border-disk-accent hover:text-white';
+
   return (
-    <div className="flex gap-2 mt-4 flex-wrap items-center">
-      <span className="text-[11px] text-[#636366]">Quick presets:</span>
-      {PRESETS.map((preset) => (
+    <div className="mt-4 space-y-2">
+      {/* Built-in presets */}
+      <div className="flex gap-2 flex-wrap items-center">
+        <span className="text-[11px] text-[#636366]">Quick presets:</span>
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            onClick={() => onLoad(preset)}
+            title={preset.description}
+            className={btnCls}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Custom presets */}
+      <div className="flex gap-2 flex-wrap items-center">
+        <span className="text-[11px] text-[#636366]">My presets:</span>
+        {customPresets.length === 0 && (
+          <span className="text-[11px] text-[#48484a]">None saved yet</span>
+        )}
+        {customPresets.map((preset) => (
+          <div key={preset.id} className="flex items-center gap-0.5">
+            {confirmDeleteId === preset.id ? (
+              <>
+                <span className="text-[11px] text-[#ff453a] mr-1">Delete "{preset.label}"?</span>
+                <button
+                  onClick={() => { onDelete(preset.id); setConfirmDeleteId(null); }}
+                  className="text-[11px] px-2 py-1 rounded-lg bg-[#ff453a]/10 border border-[#ff453a]/50 text-[#ff453a] hover:bg-[#ff453a]/20 cursor-pointer transition-colors"
+                >
+                  Yes
+                </button>
+                <button
+                  onClick={() => setConfirmDeleteId(null)}
+                  className="text-[11px] px-2 py-1 rounded-lg border border-disk-border text-[#8e8e9d] hover:bg-white/5 cursor-pointer ml-0.5 transition-colors"
+                >
+                  No
+                </button>
+              </>
+            ) : (
+              <>
+                <button onClick={() => onLoad(preset)} className={btnCls}>
+                  {preset.label}
+                </button>
+                <button
+                  onClick={() => setConfirmDeleteId(preset.id)}
+                  title="Delete preset"
+                  className="text-[12px] text-[#48484a] hover:text-[#ff453a] cursor-pointer px-1 transition-colors"
+                >
+                  ×
+                </button>
+              </>
+            )}
+          </div>
+        ))}
         <button
-          key={preset.id}
-          onClick={() => onLoad(preset)}
-          title={preset.description}
-          className="bg-disk-surface border border-disk-border rounded-lg text-[#8e8e9d] px-3 py-1.5 cursor-pointer text-[11px] font-medium transition-all hover:border-disk-accent hover:text-white"
+          onClick={onSave}
+          className="bg-disk-surface border border-disk-border rounded-lg text-[#0a84ff] px-3 py-1.5 cursor-pointer text-[11px] font-medium transition-all hover:border-[#0a84ff]/50 hover:text-[#409cff]"
         >
-          {preset.label}
+          + Save Current
         </button>
-      ))}
+      </div>
     </div>
   );
 }

--- a/src/hooks/useCustomPresets.js
+++ b/src/hooks/useCustomPresets.js
@@ -1,0 +1,36 @@
+import { useState, useCallback, useEffect } from 'react';
+
+const STORAGE_KEY = 'diskPartitionCustomPresets';
+
+export default function useCustomPresets() {
+  const [customPresets, setCustomPresets] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    } catch { return []; }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(customPresets));
+    } catch {}
+  }, [customPresets]);
+
+  const savePreset = useCallback((name, config) => {
+    const preset = {
+      id: `user-${Date.now()}`,
+      label: name,
+      disk: config.diskSizeValue,
+      unit: config.diskSizeUnit,
+      sector: String(config.sectorSize),
+      partitions: config.partitions,
+    };
+    setCustomPresets((prev) => [...prev, preset]);
+    return preset.id;
+  }, []);
+
+  const deletePreset = useCallback((id) => {
+    setCustomPresets((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  return { customPresets, savePreset, deletePreset };
+}

--- a/src/test/useCustomPresets.test.jsx
+++ b/src/test/useCustomPresets.test.jsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act, render, screen, fireEvent } from '@testing-library/react';
+import useCustomPresets from '../hooks/useCustomPresets';
+import App from '../App';
+
+const STORAGE_KEY = 'diskPartitionCustomPresets';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useCustomPresets', () => {
+  it('starts with empty presets when localStorage is empty', () => {
+    const { result } = renderHook(() => useCustomPresets());
+    expect(result.current.customPresets).toEqual([]);
+  });
+
+  it('saves a preset and persists to localStorage', () => {
+    const { result } = renderHook(() => useCustomPresets());
+
+    act(() => {
+      result.current.savePreset('My Config', {
+        diskSizeValue: '500',
+        diskSizeUnit: 'GB',
+        sectorSize: 512,
+        partitions: [{ name: 'boot', startBlock: 0, endBlock: 100 }],
+      });
+    });
+
+    expect(result.current.customPresets).toHaveLength(1);
+    expect(result.current.customPresets[0].label).toBe('My Config');
+    expect(result.current.customPresets[0].partitions).toHaveLength(1);
+
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY));
+    expect(saved).toHaveLength(1);
+    expect(saved[0].label).toBe('My Config');
+  });
+
+  it('deletes a preset by id', () => {
+    const { result } = renderHook(() => useCustomPresets());
+
+    act(() => {
+      result.current.savePreset('To Delete', {
+        diskSizeValue: '100',
+        diskSizeUnit: 'GB',
+        sectorSize: 512,
+        partitions: [],
+      });
+    });
+
+    const id = result.current.customPresets[0].id;
+
+    act(() => {
+      result.current.deletePreset(id);
+    });
+
+    expect(result.current.customPresets).toHaveLength(0);
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY))).toHaveLength(0);
+  });
+
+  it('restores presets from localStorage on init', () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([
+      { id: 'user-1', label: 'Saved', disk: '250', unit: 'GB', sector: '512', partitions: [] },
+    ]));
+
+    const { result } = renderHook(() => useCustomPresets());
+    expect(result.current.customPresets).toHaveLength(1);
+    expect(result.current.customPresets[0].label).toBe('Saved');
+  });
+});
+
+describe('Save preset UI', () => {
+  it('shows Save Current button', () => {
+    render(<App />);
+    expect(screen.getByText('+ Save Current')).toBeInTheDocument();
+  });
+
+  it('opens save modal when Save Current is clicked', () => {
+    render(<App />);
+    fireEvent.click(screen.getByText('+ Save Current'));
+    expect(screen.getByPlaceholderText('Preset name')).toBeInTheDocument();
+  });
+
+  it('closes modal on Cancel', () => {
+    render(<App />);
+    fireEvent.click(screen.getByText('+ Save Current'));
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(screen.queryByPlaceholderText('Preset name')).not.toBeInTheDocument();
+  });
+
+  it('saves preset and closes modal on Save', () => {
+    render(<App />);
+    fireEvent.click(screen.getByText('+ Save Current'));
+    fireEvent.change(screen.getByPlaceholderText('Preset name'), { target: { value: 'My Layout' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.queryByPlaceholderText('Preset name')).not.toBeInTheDocument();
+    expect(screen.getByText('My Layout')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- New `useCustomPresets` hook stores named presets in `localStorage`
- **Save Current** button opens a modal prompting for a preset name
- Custom presets appear in a "My presets" row below the built-in ones
- Each custom preset has a **×** button that asks for inline confirmation before deleting
- Built-in presets are unchanged
- Reset button is unaffected (resets layout only, never touches saved presets)

## Tests (8 new in `useCustomPresets.test.jsx`)

- Starts empty when localStorage is empty
- Saves preset and persists to localStorage
- Deletes preset by id
- Restores presets from localStorage on init
- Save Current button is visible
- Opens modal on click
- Cancel closes modal
- Confirms save and shows new preset in the bar

Closes #19