### PR TITLE
Add zoom and pan to disk bar visualization

### DIFF
--- a/src/components/DiskBar.jsx
+++ b/src/components/DiskBar.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { UNALLOC_COLOR, OVERLAP_COLOR, PARTITION_COLORS } from '../utils';
 import { formatBlocks } from '../utils';
 
@@ -13,8 +13,11 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
   const [hovered, setHovered] = useState(null);
   const barRef = useRef(null);
   const scrollRef = useRef(null);
+  const minimapRef = useRef(null);
   const [tipPos, setTipPos] = useState({ x: 0, visible: false });
   const [zoom, setZoom] = useState(1);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
 
   const handleMouse = (i, e) => {
     if (barRef.current) {
@@ -39,9 +42,32 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
   const zoomOut = () => setZoom((z) => Math.max(MIN_ZOOM, z - 1));
   const resetZoom = () => setZoom(1);
 
+  const scrollToMinimapPct = useCallback((clientX) => {
+    const minimap = minimapRef.current;
+    const scroll = scrollRef.current;
+    if (!minimap || !scroll) return;
+    const rect = minimap.getBoundingClientRect();
+    const clickPct = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    const viewportHalf = 1 / (2 * zoom);
+    const newScrollPct = Math.max(0, Math.min(1, (clickPct - viewportHalf) / (1 - 1 / zoom)));
+    scroll.scrollLeft = newScrollPct * (scroll.scrollWidth - scroll.clientWidth);
+  }, [zoom]);
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const onMove = (e) => scrollToMinimapPct(e.clientX);
+    const onUp = () => { setIsDragging(false); setHovered(null); };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [isDragging, scrollToMinimapPct]);
+
   // Visible LBA range for the ruler
   const scrollEl = scrollRef.current;
-  const scrollPct = scrollEl ? scrollEl.scrollLeft / (scrollEl.scrollWidth - scrollEl.clientWidth || 1) : 0;
+  const scrollPct = scrollEl ? scrollLeft / (scrollEl.scrollWidth - scrollEl.clientWidth || 1) : 0;
   const visibleBlocks = Math.floor(totalBlocks / zoom);
   const startLBA = Math.floor(scrollPct * (totalBlocks - visibleBlocks));
   const endLBA = Math.min(totalBlocks, startLBA + visibleBlocks);
@@ -94,6 +120,7 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
         ref={scrollRef}
         className="overflow-x-auto"
         onWheel={handleWheel}
+        onScroll={(e) => setScrollLeft(e.currentTarget.scrollLeft)}
         style={{ scrollbarWidth: zoom > 1 ? 'thin' : 'none' }}
       >
         {/* Main bar */}
@@ -132,7 +159,7 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
                   height: '100%',
                   background: bg,
                   borderRight: '1px solid #0F172A',
-                  opacity: hovered !== null && !isHov ? 0.6 : 1,
+                  opacity: !isDragging && hovered !== null && !isHov ? 0.6 : 1,
                   boxShadow: isHov ? 'inset 0 0 0 2px rgba(248,250,252,0.27)' : 'none',
                 }}
               >
@@ -177,23 +204,28 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
         <div className="mt-2">
           <div className="text-[8px] font-mono text-slate-700 mb-0.5">Overview</div>
           <div
-            className="flex w-full h-[10px] rounded overflow-hidden border border-slate-800"
+            ref={minimapRef}
+            className="relative w-full h-[10px] rounded overflow-hidden border border-slate-800 cursor-pointer select-none"
             style={{ background: UNALLOC_COLOR }}
+            onMouseDown={(e) => { setIsDragging(true); setHovered(null); scrollToMinimapPct(e.clientX); }}
           >
-            {segments.map((seg, i) => {
-              const pct = (seg.blocks / totalBlocks) * 100;
-              if (pct < 0.1) return null;
-              let bg;
-              if (seg.type === 'unallocated') bg = UNALLOC_COLOR;
-              else if (seg.type === 'overlap') bg = OVERLAP_COLOR;
-              else bg = seg.color;
-              return (
-                <div key={i} style={{ width: `${pct}%`, background: bg, opacity: 0.8 }} />
-              );
-            })}
+            {/* Segments */}
+            <div className="flex w-full h-full">
+              {segments.map((seg, i) => {
+                const pct = (seg.blocks / totalBlocks) * 100;
+                if (pct < 0.1) return null;
+                let bg;
+                if (seg.type === 'unallocated') bg = UNALLOC_COLOR;
+                else if (seg.type === 'overlap') bg = OVERLAP_COLOR;
+                else bg = seg.color;
+                return (
+                  <div key={i} style={{ width: `${pct}%`, background: bg, opacity: 0.8 }} />
+                );
+              })}
+            </div>
             {/* Viewport indicator */}
             <div
-              className="absolute h-[10px] border border-white/30 bg-white/5 pointer-events-none"
+              className="absolute top-0 h-full border border-white/50 bg-white/10 pointer-events-none"
               style={{
                 width: `${(1 / zoom) * 100}%`,
                 left: `${scrollPct * (1 - 1 / zoom) * 100}%`,

--- a/src/components/DiskBar.jsx
+++ b/src/components/DiskBar.jsx
@@ -1,15 +1,20 @@
-import { useState, useRef } from 'react';
+import { useState, useRef, useCallback } from 'react';
 import { UNALLOC_COLOR, OVERLAP_COLOR, PARTITION_COLORS } from '../utils';
 import { formatBlocks } from '../utils';
 
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 10;
+
 /**
  * Rectangular "Disk Manager" style bar showing block layout with LBA ruler,
- * partition boundaries, and hover tooltips.
+ * partition boundaries, hover tooltips, and zoom/pan support.
  */
 export default function DiskBar({ segments, totalBlocks, partitions }) {
   const [hovered, setHovered] = useState(null);
   const barRef = useRef(null);
+  const scrollRef = useRef(null);
   const [tipPos, setTipPos] = useState({ x: 0, visible: false });
+  const [zoom, setZoom] = useState(1);
 
   const handleMouse = (i, e) => {
     if (barRef.current) {
@@ -24,86 +29,179 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
     setTipPos((p) => ({ ...p, visible: false }));
   };
 
+  const handleWheel = useCallback((e) => {
+    if (!e.ctrlKey && !e.metaKey) return;
+    e.preventDefault();
+    setZoom((z) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, z + (e.deltaY < 0 ? 1 : -1))));
+  }, []);
+
+  const zoomIn = () => setZoom((z) => Math.min(MAX_ZOOM, z + 1));
+  const zoomOut = () => setZoom((z) => Math.max(MIN_ZOOM, z - 1));
+  const resetZoom = () => setZoom(1);
+
+  // Visible LBA range for the ruler
+  const scrollEl = scrollRef.current;
+  const scrollPct = scrollEl ? scrollEl.scrollLeft / (scrollEl.scrollWidth - scrollEl.clientWidth || 1) : 0;
+  const visibleBlocks = Math.floor(totalBlocks / zoom);
+  const startLBA = Math.floor(scrollPct * (totalBlocks - visibleBlocks));
+  const endLBA = Math.min(totalBlocks, startLBA + visibleBlocks);
+
   return (
     <div className="relative">
+      {/* Zoom controls */}
+      <div className="flex items-center gap-2 mb-2">
+        <button
+          onClick={zoomOut}
+          disabled={zoom <= MIN_ZOOM}
+          className="text-[10px] font-mono px-2 py-0.5 rounded border border-slate-700 text-slate-400 hover:border-slate-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          −
+        </button>
+        <span className="text-[9px] font-mono text-slate-500 w-6 text-center">{zoom}×</span>
+        <button
+          onClick={zoomIn}
+          disabled={zoom >= MAX_ZOOM}
+          className="text-[10px] font-mono px-2 py-0.5 rounded border border-slate-700 text-slate-400 hover:border-slate-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          +
+        </button>
+        {zoom > 1 && (
+          <button
+            onClick={resetZoom}
+            className="text-[9px] font-mono px-2 py-0.5 rounded border border-slate-700 text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            reset
+          </button>
+        )}
+        {zoom > 1 && (
+          <span className="text-[9px] font-mono text-slate-600 ml-1">
+            LBA {startLBA.toLocaleString()} – {endLBA.toLocaleString()}
+          </span>
+        )}
+        {zoom === 1 && (
+          <span className="text-[9px] font-mono text-slate-700">Ctrl+scroll to zoom</span>
+        )}
+      </div>
+
       {/* LBA ruler */}
       <div className="flex justify-between mb-1 font-mono text-[9px] text-slate-600">
-        <span>LBA 0</span>
-        <span>LBA {totalBlocks.toLocaleString()}</span>
+        <span>LBA {zoom > 1 ? startLBA.toLocaleString() : '0'}</span>
+        <span>LBA {zoom > 1 ? endLBA.toLocaleString() : totalBlocks.toLocaleString()}</span>
       </div>
 
-      {/* Main bar */}
+      {/* Scrollable zoom container */}
       <div
-        ref={barRef}
-        className="flex w-full h-[52px] rounded-md overflow-hidden border border-slate-700"
-        style={{
-          background: `repeating-linear-gradient(90deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 2px, #162032 2px, #162032 4px)`,
-        }}
+        ref={scrollRef}
+        className="overflow-x-auto"
+        onWheel={handleWheel}
+        style={{ scrollbarWidth: zoom > 1 ? 'thin' : 'none' }}
       >
-        {segments.map((seg, i) => {
-          const pct = (seg.blocks / totalBlocks) * 100;
-          if (pct < 0.15) return null;
-          const isHov = hovered === i;
+        {/* Main bar */}
+        <div
+          ref={barRef}
+          className="flex h-[52px] rounded-md overflow-hidden border border-slate-700"
+          style={{
+            width: `${zoom * 100}%`,
+            minWidth: '100%',
+            background: `repeating-linear-gradient(90deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 2px, #162032 2px, #162032 4px)`,
+          }}
+        >
+          {segments.map((seg, i) => {
+            const pct = (seg.blocks / totalBlocks) * 100;
+            if (pct < 0.15 / zoom) return null;
+            const isHov = hovered === i;
 
-          let bg;
-          if (seg.type === 'unallocated') {
-            bg = `repeating-linear-gradient(135deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 3px, #1a2940 3px, #1a2940 6px)`;
-          } else if (seg.type === 'overlap') {
-            bg = `repeating-linear-gradient(45deg, ${OVERLAP_COLOR}CC 0px, ${OVERLAP_COLOR}CC 3px, ${OVERLAP_COLOR}88 3px, ${OVERLAP_COLOR}88 6px)`;
-          } else {
-            bg = seg.color;
-          }
+            let bg;
+            if (seg.type === 'unallocated') {
+              bg = `repeating-linear-gradient(135deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 3px, #1a2940 3px, #1a2940 6px)`;
+            } else if (seg.type === 'overlap') {
+              bg = `repeating-linear-gradient(45deg, ${OVERLAP_COLOR}CC 0px, ${OVERLAP_COLOR}CC 3px, ${OVERLAP_COLOR}88 3px, ${OVERLAP_COLOR}88 6px)`;
+            } else {
+              bg = seg.color;
+            }
 
-          return (
-            <div
-              key={i}
-              onMouseEnter={(e) => handleMouse(i, e)}
-              onMouseMove={(e) => handleMouse(i, e)}
-              onMouseLeave={clearHover}
-              className="relative transition-opacity duration-150 cursor-pointer"
-              style={{
-                width: `${pct}%`,
-                height: '100%',
-                background: bg,
-                borderRight: '1px solid #0F172A',
-                opacity: hovered !== null && !isHov ? 0.6 : 1,
-                boxShadow: isHov ? 'inset 0 0 0 2px rgba(248,250,252,0.27)' : 'none',
-              }}
-            >
-              {pct > 6 && (
-                <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[8px] font-mono font-semibold text-white whitespace-nowrap pointer-events-none" style={{ textShadow: '0 1px 3px #000' }}>
-                  {seg.label}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
-      {/* Boundary tick marks */}
-      <div className="relative h-[18px]">
-        {partitions.map((p, i) => {
-          const startPct = (p.startBlock / totalBlocks) * 100;
-          return (
-            <div key={i}>
+            return (
               <div
-                className="absolute top-0 w-px h-2"
-                style={{ left: `${startPct}%`, background: PARTITION_COLORS[i % PARTITION_COLORS.length] + '88' }}
-              />
-              <div
-                className="absolute top-0 w-px h-2"
-                style={{ left: `${(p.endBlock / totalBlocks) * 100}%`, background: PARTITION_COLORS[i % PARTITION_COLORS.length] + '88' }}
-              />
-              <div
-                className="absolute font-mono text-[7px] text-slate-600 -translate-x-1/2 whitespace-nowrap"
-                style={{ left: `${startPct}%`, top: 9 }}
+                key={i}
+                onMouseEnter={(e) => handleMouse(i, e)}
+                onMouseMove={(e) => handleMouse(i, e)}
+                onMouseLeave={clearHover}
+                className="relative transition-opacity duration-150 cursor-pointer"
+                style={{
+                  width: `${pct}%`,
+                  height: '100%',
+                  background: bg,
+                  borderRight: '1px solid #0F172A',
+                  opacity: hovered !== null && !isHov ? 0.6 : 1,
+                  boxShadow: isHov ? 'inset 0 0 0 2px rgba(248,250,252,0.27)' : 'none',
+                }}
               >
-                {formatBlocks(p.startBlock)}
+                {pct * zoom > 6 && (
+                  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[8px] font-mono font-semibold text-white whitespace-nowrap pointer-events-none" style={{ textShadow: '0 1px 3px #000' }}>
+                    {seg.label}
+                  </div>
+                )}
               </div>
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
+
+        {/* Boundary tick marks */}
+        <div className="relative h-[18px]" style={{ width: `${zoom * 100}%`, minWidth: '100%' }}>
+          {partitions.map((p, i) => {
+            const startPct = (p.startBlock / totalBlocks) * 100;
+            return (
+              <div key={i}>
+                <div
+                  className="absolute top-0 w-px h-2"
+                  style={{ left: `${startPct}%`, background: PARTITION_COLORS[i % PARTITION_COLORS.length] + '88' }}
+                />
+                <div
+                  className="absolute top-0 w-px h-2"
+                  style={{ left: `${(p.endBlock / totalBlocks) * 100}%`, background: PARTITION_COLORS[i % PARTITION_COLORS.length] + '88' }}
+                />
+                <div
+                  className="absolute font-mono text-[7px] text-slate-600 -translate-x-1/2 whitespace-nowrap"
+                  style={{ left: `${startPct}%`, top: 9 }}
+                >
+                  {formatBlocks(p.startBlock)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
+
+      {/* Minimap (shown when zoomed) */}
+      {zoom > 1 && (
+        <div className="mt-2">
+          <div className="text-[8px] font-mono text-slate-700 mb-0.5">Overview</div>
+          <div
+            className="flex w-full h-[10px] rounded overflow-hidden border border-slate-800"
+            style={{ background: UNALLOC_COLOR }}
+          >
+            {segments.map((seg, i) => {
+              const pct = (seg.blocks / totalBlocks) * 100;
+              if (pct < 0.1) return null;
+              let bg;
+              if (seg.type === 'unallocated') bg = UNALLOC_COLOR;
+              else if (seg.type === 'overlap') bg = OVERLAP_COLOR;
+              else bg = seg.color;
+              return (
+                <div key={i} style={{ width: `${pct}%`, background: bg, opacity: 0.8 }} />
+              );
+            })}
+            {/* Viewport indicator */}
+            <div
+              className="absolute h-[10px] border border-white/30 bg-white/5 pointer-events-none"
+              style={{
+                width: `${(1 / zoom) * 100}%`,
+                left: `${scrollPct * (1 - 1 / zoom) * 100}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Tooltip */}
       {tipPos.visible && hovered !== null && segments[hovered] && (

--- a/src/test/DiskBar.test.jsx
+++ b/src/test/DiskBar.test.jsx
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import DiskBar from '../components/DiskBar';
+
+const TOTAL_BLOCKS = 1000;
+
+const segments = [
+  { label: 'Root', type: 'partition', color: '#3B82F6', blocks: 500, startBlock: 0, endBlock: 500 },
+  { label: 'Home', type: 'partition', color: '#10B981', blocks: 400, startBlock: 500, endBlock: 900 },
+  { label: 'Free', type: 'unallocated', color: '#334155', blocks: 100, startBlock: 900, endBlock: 1000 },
+];
+
+const partitions = [
+  { name: 'Root', startBlock: 0, endBlock: 500 },
+  { name: 'Home', startBlock: 500, endBlock: 900 },
+];
+
+function renderBar(props = {}) {
+  return render(
+    <DiskBar
+      segments={segments}
+      totalBlocks={TOTAL_BLOCKS}
+      partitions={partitions}
+      {...props}
+    />
+  );
+}
+
+// ─── Rendering ───────────────────────────────────────────────────────────────
+
+describe('DiskBar — rendering', () => {
+  it('renders partition labels for large-enough segments', () => {
+    renderBar();
+    expect(screen.getByText('Root')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+
+  it('renders the LBA ruler with 0 and total at zoom 1', () => {
+    renderBar();
+    expect(screen.getByText('LBA 0')).toBeInTheDocument();
+    expect(screen.getByText(`LBA ${TOTAL_BLOCKS.toLocaleString()}`)).toBeInTheDocument();
+  });
+
+  it('renders zoom controls', () => {
+    renderBar();
+    expect(screen.getByText('−')).toBeInTheDocument();
+    expect(screen.getByText('+')).toBeInTheDocument();
+    expect(screen.getByText('1×')).toBeInTheDocument();
+  });
+
+  it('shows Ctrl+scroll hint at zoom 1', () => {
+    renderBar();
+    expect(screen.getByText(/ctrl\+scroll to zoom/i)).toBeInTheDocument();
+  });
+
+  it('does not show the minimap at zoom 1', () => {
+    renderBar();
+    expect(screen.queryByText('Overview')).not.toBeInTheDocument();
+  });
+
+  it('does not show the reset button at zoom 1', () => {
+    renderBar();
+    expect(screen.queryByText('reset')).not.toBeInTheDocument();
+  });
+});
+
+// ─── Tiny segment filtering ───────────────────────────────────────────────────
+
+describe('DiskBar — segment filtering', () => {
+  it('does not render segments below the 0.15% visibility threshold', () => {
+    const tinySegments = [
+      { label: 'Tiny', type: 'partition', color: '#f00', blocks: 1, startBlock: 0, endBlock: 1 },
+      { label: 'Big', type: 'partition', color: '#0f0', blocks: 999, startBlock: 1, endBlock: 1000 },
+    ];
+    renderBar({ segments: tinySegments });
+    // "Tiny" is 0.1% which is below 0.15/1 threshold — label won't render
+    expect(screen.queryByText('Tiny')).not.toBeInTheDocument();
+    expect(screen.getByText('Big')).toBeInTheDocument();
+  });
+});
+
+// ─── Zoom controls ───────────────────────────────────────────────────────────
+
+describe('DiskBar — zoom controls', () => {
+  it('− button is disabled at zoom 1', () => {
+    renderBar();
+    expect(screen.getByText('−').closest('button')).toBeDisabled();
+  });
+
+  it('+ button is enabled at zoom 1', () => {
+    renderBar();
+    expect(screen.getByText('+').closest('button')).not.toBeDisabled();
+  });
+
+  it('clicking + increments the zoom level display', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    expect(screen.getByText('2×')).toBeInTheDocument();
+  });
+
+  it('shows the reset button after zooming in', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    expect(screen.getByText('reset')).toBeInTheDocument();
+  });
+
+  it('clicking reset returns zoom to 1×', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    fireEvent.click(screen.getByText('+'));
+    fireEvent.click(screen.getByText('reset'));
+    expect(screen.getByText('1×')).toBeInTheDocument();
+    expect(screen.queryByText('reset')).not.toBeInTheDocument();
+  });
+
+  it('does not exceed MAX_ZOOM (10×)', () => {
+    renderBar();
+    const plusBtn = screen.getByText('+').closest('button');
+    for (let i = 0; i < 15; i++) fireEvent.click(plusBtn);
+    expect(screen.getByText('10×')).toBeInTheDocument();
+    expect(plusBtn).toBeDisabled();
+  });
+
+  it('does not go below MIN_ZOOM (1×)', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    fireEvent.click(screen.getByText('−'));
+    fireEvent.click(screen.getByText('−'));
+    expect(screen.getByText('1×')).toBeInTheDocument();
+    expect(screen.getByText('−').closest('button')).toBeDisabled();
+  });
+});
+
+// ─── Minimap ─────────────────────────────────────────────────────────────────
+
+describe('DiskBar — minimap', () => {
+  it('shows the minimap after zooming in', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+  });
+
+  it('hides the minimap after resetting zoom', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    fireEvent.click(screen.getByText('reset'));
+    expect(screen.queryByText('Overview')).not.toBeInTheDocument();
+  });
+});
+
+// ─── LBA ruler ───────────────────────────────────────────────────────────────
+
+describe('DiskBar — LBA ruler when zoomed', () => {
+  it('shows LBA range in the zoom controls bar when zoomed', () => {
+    renderBar();
+    fireEvent.click(screen.getByText('+'));
+    // At zoom=2 scrollLeft=0: startLBA=0, visibleBlocks=500, endLBA=500
+    expect(screen.getByText(/LBA 0\s*[–—]\s*500/)).toBeInTheDocument();
+  });
+});
+
+// ─── Hover behaviour ─────────────────────────────────────────────────────────
+
+describe('DiskBar — hover dimming', () => {
+  it('dims non-hovered segments when one segment is hovered', () => {
+    const { container } = renderBar();
+    const bar = container.querySelector('[style*="width: 50%"]'); // Root is 50%
+    fireEvent.mouseEnter(bar, { clientX: 0 });
+
+    // Home segment (40%) should be dimmed
+    const homeSegment = container.querySelector('[style*="width: 40%"]');
+    expect(homeSegment.style.opacity).toBe('0.6');
+  });
+
+  it('restores full opacity on mouse leave', () => {
+    const { container } = renderBar();
+    const bar = container.querySelector('[style*="width: 50%"]');
+    fireEvent.mouseEnter(bar, { clientX: 0 });
+    fireEvent.mouseLeave(bar);
+
+    const homeSegment = container.querySelector('[style*="width: 40%"]');
+    expect(homeSegment.style.opacity).toBe('1');
+  });
+});


### PR DESCRIPTION
## Summary

Small partitions on large drives become invisible slivers at 1× scale. This adds zoom/pan so users can inspect them.

## Features

- **+/−** buttons and **Ctrl+scroll** to zoom up to 10×
- Horizontal scroll to pan when zoomed in
- LBA ruler updates to show the visible block range while zoomed
- **Minimap** shows the full drive layout with a viewport indicator when zoomed
- Partition labels appear when a segment is wide enough at the current zoom level
- Small-segment hiding threshold scales with zoom (so tiny partitions become visible when zoomed in)
- **Reset** button returns to 1× zoom

Closes #18