### PR TITLE
Apply macOS-inspired UI theme and visual refresh

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -50,43 +50,43 @@ export default function App() {
       <div className="max-w-[900px] mx-auto mb-7">
         <div className="flex items-center justify-between mb-1">
           <div className="flex items-center gap-2.5">
-            <div className="w-8 h-8">
+            <div className="w-7 h-7">
               <img src={`${import.meta.env.BASE_URL}favicon.svg`} alt="logo" className="w-full h-full" />
             </div>
-            <h1 className="m-0 text-[22px] font-display font-bold text-slate-50 tracking-tight">
+            <h1 className="m-0 text-[20px] font-display font-bold text-white tracking-tight">
               Disk Partition Visualizer
             </h1>
           </div>
           <button
             onClick={() => setConfirmReset(true)}
-            className="text-[11px] font-mono px-3 py-1.5 rounded-md border border-red-800 text-red-400 hover:bg-red-900/30 transition-colors"
+            className="text-[12px] px-3 py-1.5 rounded-lg border border-[#3a3a3c] text-[#ff453a] hover:bg-[#ff453a]/10 hover:border-[#ff453a]/50 transition-colors"
           >
             Reset
           </button>
         </div>
-        <p className="m-0 text-[11px] text-slate-500 ml-[42px] font-mono">
+        <p className="m-0 text-[11px] text-[#48484a] ml-[38px] font-mono">
           Interactive block-level partition layout · LBA addressing · Overlap detection
         </p>
       </div>
 
       {/* Reset confirmation dialog */}
       {confirmReset && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
-          <div className="bg-disk-surface border border-disk-border rounded-xl p-6 max-w-sm w-full mx-4 shadow-xl">
-            <h2 className="text-slate-100 font-semibold text-base mb-2">Reset all data?</h2>
-            <p className="text-slate-400 text-[13px] mb-5">
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 backdrop-blur-sm">
+          <div className="bg-disk-surface border border-disk-border rounded-2xl p-6 max-w-sm w-full mx-4 shadow-2xl">
+            <h2 className="text-white font-semibold text-[15px] mb-2">Reset all data?</h2>
+            <p className="text-[#8e8e9d] text-[13px] mb-5 leading-relaxed">
               This will clear all partitions and restore the default disk configuration.
             </p>
             <div className="flex gap-3 justify-end">
               <button
                 onClick={() => setConfirmReset(false)}
-                className="text-[12px] font-mono px-4 py-1.5 rounded-md border border-disk-border text-slate-400 hover:bg-white/5 transition-colors"
+                className="text-[13px] px-4 py-1.5 rounded-lg border border-disk-border text-[#8e8e9d] hover:bg-white/5 transition-colors"
               >
                 Cancel
               </button>
               <button
                 onClick={handleReset}
-                className="text-[12px] font-mono px-4 py-1.5 rounded-md bg-red-600 hover:bg-red-700 text-white transition-colors"
+                className="text-[13px] px-4 py-1.5 rounded-lg bg-[#ff453a] hover:bg-[#ff6961] text-white transition-colors font-medium"
               >
                 Reset
               </button>
@@ -96,7 +96,6 @@ export default function App() {
       )}
 
       <div className="max-w-[900px] mx-auto">
-        {/* Disk configuration */}
         <DiskConfig
           diskSizeValue={disk.diskSizeValue}
           setDiskSizeValue={disk.setDiskSizeValue}
@@ -113,20 +112,20 @@ export default function App() {
           overlapBlocks={disk.overlapBlocks}
         />
 
-        {/* Visualizations: pie chart + disk bar */}
+        {/* Visualizations */}
         <div className="grid grid-cols-[280px_1fr] gap-4 mb-4 max-lg:grid-cols-1">
           {/* Pie chart panel */}
-          <div className="bg-disk-surface rounded-[10px] p-4 border border-disk-border flex flex-col items-center">
-            <div className="text-[10px] text-slate-400 font-mono font-semibold uppercase tracking-wider mb-2.5 self-start">
-              ◔ Allocation Chart
+          <div className="bg-disk-surface rounded-xl p-4 border border-disk-border flex flex-col items-center">
+            <div className="text-[11px] text-[#8e8e9d] font-semibold uppercase tracking-widest mb-3 self-start">
+              ◔ Allocation
             </div>
             <PieChart segments={disk.segments} totalBlocks={disk.totalBlocks} />
             <Legend segments={disk.segments} totalBlocks={disk.totalBlocks} />
           </div>
 
           {/* Disk bar panel */}
-          <div className="bg-disk-surface rounded-[10px] p-4 border border-disk-border">
-            <div className="text-[10px] text-slate-400 font-mono font-semibold uppercase tracking-wider mb-3">
+          <div className="bg-disk-surface rounded-xl p-4 border border-disk-border">
+            <div className="text-[11px] text-[#8e8e9d] font-semibold uppercase tracking-widest mb-3">
               ▭ Block Layout (LBA)
             </div>
             <DiskBar
@@ -145,7 +144,6 @@ export default function App() {
           </div>
         </div>
 
-        {/* Create / edit partition */}
         <PartitionForm
           partitions={disk.partitions}
           overlaps={disk.overlaps}
@@ -156,12 +154,10 @@ export default function App() {
           setEditIdx={setEditIdx}
         />
 
-        {/* Presets */}
         <PresetBar onLoad={handleLoadPreset} />
 
-        {/* Footer */}
-        <div className="text-center mt-6 text-[9px] text-slate-700 font-mono">
-          Built by Amol · Interactive Disk Partition Visualizer
+        <div className="text-center mt-6 text-[10px] text-[#3a3a3c]">
+          Built by Amol · Disk Partition Visualizer
         </div>
       </div>
     </div>

--- a/src/components/DiskBar.jsx
+++ b/src/components/DiskBar.jsx
@@ -5,10 +5,6 @@ import { formatBlocks } from '../utils';
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 10;
 
-/**
- * Rectangular "Disk Manager" style bar showing block layout with LBA ruler,
- * partition boundaries, hover tooltips, and zoom/pan support.
- */
 export default function DiskBar({ segments, totalBlocks, partitions }) {
   const [hovered, setHovered] = useState(null);
   const barRef = useRef(null);
@@ -65,52 +61,36 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
     };
   }, [isDragging, scrollToMinimapPct]);
 
-  // Visible LBA range for the ruler
   const scrollEl = scrollRef.current;
   const scrollPct = scrollEl ? scrollLeft / (scrollEl.scrollWidth - scrollEl.clientWidth || 1) : 0;
   const visibleBlocks = Math.floor(totalBlocks / zoom);
   const startLBA = Math.floor(scrollPct * (totalBlocks - visibleBlocks));
   const endLBA = Math.min(totalBlocks, startLBA + visibleBlocks);
 
+  const btnCls = 'text-[11px] font-mono px-2 py-0.5 rounded-md border border-disk-border text-[#8e8e9d] hover:border-disk-border-light hover:text-white disabled:opacity-25 disabled:cursor-not-allowed transition-colors';
+
   return (
     <div className="relative">
       {/* Zoom controls */}
       <div className="flex items-center gap-2 mb-2">
-        <button
-          onClick={zoomOut}
-          disabled={zoom <= MIN_ZOOM}
-          className="text-[10px] font-mono px-2 py-0.5 rounded border border-slate-700 text-slate-400 hover:border-slate-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-        >
-          −
-        </button>
-        <span className="text-[9px] font-mono text-slate-500 w-6 text-center">{zoom}×</span>
-        <button
-          onClick={zoomIn}
-          disabled={zoom >= MAX_ZOOM}
-          className="text-[10px] font-mono px-2 py-0.5 rounded border border-slate-700 text-slate-400 hover:border-slate-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-        >
-          +
-        </button>
+        <button onClick={zoomOut} disabled={zoom <= MIN_ZOOM} className={btnCls}>−</button>
+        <span className="text-[10px] font-mono text-[#636366] w-6 text-center">{zoom}×</span>
+        <button onClick={zoomIn} disabled={zoom >= MAX_ZOOM} className={btnCls}>+</button>
         {zoom > 1 && (
-          <button
-            onClick={resetZoom}
-            className="text-[9px] font-mono px-2 py-0.5 rounded border border-slate-700 text-slate-500 hover:text-slate-300 transition-colors"
-          >
-            reset
-          </button>
+          <button onClick={resetZoom} className={btnCls}>reset</button>
         )}
         {zoom > 1 && (
-          <span className="text-[9px] font-mono text-slate-600 ml-1">
+          <span className="text-[10px] font-mono text-[#636366] ml-1">
             LBA {startLBA.toLocaleString()} – {endLBA.toLocaleString()}
           </span>
         )}
         {zoom === 1 && (
-          <span className="text-[9px] font-mono text-slate-700">Ctrl+scroll to zoom</span>
+          <span className="text-[10px] font-mono text-[#48484a]">Ctrl+scroll to zoom</span>
         )}
       </div>
 
       {/* LBA ruler */}
-      <div className="flex justify-between mb-1 font-mono text-[9px] text-slate-600">
+      <div className="flex justify-between mb-1 font-mono text-[9px] text-[#48484a]">
         <span>LBA {zoom > 1 ? startLBA.toLocaleString() : '0'}</span>
         <span>LBA {zoom > 1 ? endLBA.toLocaleString() : totalBlocks.toLocaleString()}</span>
       </div>
@@ -126,11 +106,11 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
         {/* Main bar */}
         <div
           ref={barRef}
-          className="flex h-[52px] rounded-md overflow-hidden border border-slate-700"
+          className="flex h-[52px] rounded-lg overflow-hidden border border-disk-border"
           style={{
             width: `${zoom * 100}%`,
             minWidth: '100%',
-            background: `repeating-linear-gradient(90deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 2px, #162032 2px, #162032 4px)`,
+            background: `repeating-linear-gradient(90deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 2px, #2c2c2e 2px, #2c2c2e 4px)`,
           }}
         >
           {segments.map((seg, i) => {
@@ -140,7 +120,7 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
 
             let bg;
             if (seg.type === 'unallocated') {
-              bg = `repeating-linear-gradient(135deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 3px, #1a2940 3px, #1a2940 6px)`;
+              bg = `repeating-linear-gradient(135deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 3px, #2c2c2e 3px, #2c2c2e 6px)`;
             } else if (seg.type === 'overlap') {
               bg = `repeating-linear-gradient(45deg, ${OVERLAP_COLOR}CC 0px, ${OVERLAP_COLOR}CC 3px, ${OVERLAP_COLOR}88 3px, ${OVERLAP_COLOR}88 6px)`;
             } else {
@@ -158,13 +138,13 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
                   width: `${pct}%`,
                   height: '100%',
                   background: bg,
-                  borderRight: '1px solid #0F172A',
+                  borderRight: '1px solid #1c1c1e',
                   opacity: !isDragging && hovered !== null && !isHov ? 0.6 : 1,
-                  boxShadow: isHov ? 'inset 0 0 0 2px rgba(248,250,252,0.27)' : 'none',
+                  boxShadow: isHov ? 'inset 0 0 0 2px rgba(255,255,255,0.2)' : 'none',
                 }}
               >
                 {pct * zoom > 6 && (
-                  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[8px] font-mono font-semibold text-white whitespace-nowrap pointer-events-none" style={{ textShadow: '0 1px 3px #000' }}>
+                  <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-[8px] font-mono font-semibold text-white whitespace-nowrap pointer-events-none" style={{ textShadow: '0 1px 4px rgba(0,0,0,0.8)' }}>
                     {seg.label}
                   </div>
                 )}
@@ -188,7 +168,7 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
                   style={{ left: `${(p.endBlock / totalBlocks) * 100}%`, background: PARTITION_COLORS[i % PARTITION_COLORS.length] + '88' }}
                 />
                 <div
-                  className="absolute font-mono text-[7px] text-slate-600 -translate-x-1/2 whitespace-nowrap"
+                  className="absolute font-mono text-[7px] text-[#48484a] -translate-x-1/2 whitespace-nowrap"
                   style={{ left: `${startPct}%`, top: 9 }}
                 >
                   {formatBlocks(p.startBlock)}
@@ -199,17 +179,16 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
         </div>
       </div>
 
-      {/* Minimap (shown when zoomed) */}
+      {/* Minimap */}
       {zoom > 1 && (
         <div className="mt-2">
-          <div className="text-[8px] font-mono text-slate-700 mb-0.5">Overview</div>
+          <div className="text-[9px] text-[#48484a] mb-0.5">Overview</div>
           <div
             ref={minimapRef}
-            className="relative w-full h-[10px] rounded overflow-hidden border border-slate-800 cursor-pointer select-none"
+            className="relative w-full h-[10px] rounded-md overflow-hidden border border-disk-border cursor-pointer select-none"
             style={{ background: UNALLOC_COLOR }}
             onMouseDown={(e) => { setIsDragging(true); setHovered(null); scrollToMinimapPct(e.clientX); }}
           >
-            {/* Segments */}
             <div className="flex w-full h-full">
               {segments.map((seg, i) => {
                 const pct = (seg.blocks / totalBlocks) * 100;
@@ -223,9 +202,8 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
                 );
               })}
             </div>
-            {/* Viewport indicator */}
             <div
-              className="absolute top-0 h-full border border-white/50 bg-white/10 pointer-events-none"
+              className="absolute top-0 h-full border border-white/40 bg-white/10 pointer-events-none"
               style={{
                 width: `${(1 / zoom) * 100}%`,
                 left: `${scrollPct * (1 - 1 / zoom) * 100}%`,
@@ -238,21 +216,22 @@ export default function DiskBar({ segments, totalBlocks, partitions }) {
       {/* Tooltip */}
       {tipPos.visible && hovered !== null && segments[hovered] && (
         <div
-          className="absolute pointer-events-none z-10 font-mono text-[10px] text-slate-200 rounded-md border border-slate-600 backdrop-blur-md shadow-xl"
+          className="absolute pointer-events-none z-10 text-[11px] rounded-xl border border-disk-border shadow-2xl"
           style={{
-            top: -56,
+            top: -62,
             left: Math.min(tipPos.x, 260),
-            background: '#1E293BEE',
-            padding: '6px 10px',
+            background: '#2c2c2eF0',
+            backdropFilter: 'blur(12px)',
+            padding: '8px 12px',
           }}
         >
-          <div className="font-bold mb-0.5" style={{ color: segments[hovered].color }}>
+          <div className="font-semibold mb-1" style={{ color: segments[hovered].color }}>
             {segments[hovered].label}
           </div>
-          <div>
-            Blocks {segments[hovered].startBlock?.toLocaleString()} → {segments[hovered].endBlock?.toLocaleString()}
+          <div className="font-mono text-[10px] text-[#8e8e9d]">
+            LBA {segments[hovered].startBlock?.toLocaleString()} → {segments[hovered].endBlock?.toLocaleString()}
           </div>
-          <div className="text-slate-400">
+          <div className="font-mono text-[10px] text-[#636366]">
             {formatBlocks(segments[hovered].blocks)} blocks · {((segments[hovered].blocks / totalBlocks) * 100).toFixed(2)}%
           </div>
         </div>

--- a/src/components/DiskConfig.jsx
+++ b/src/components/DiskConfig.jsx
@@ -1,8 +1,5 @@
 import { formatSize, formatBlocks, SECTOR_SIZES } from '../utils';
 
-/**
- * Configuration panel for disk size, sector size, and computed stats.
- */
 export default function DiskConfig({
   diskSizeValue,
   setDiskSizeValue,
@@ -19,17 +16,16 @@ export default function DiskConfig({
   overlapBlocks,
 }) {
   const inputCls =
-    'bg-[#0F172A] border border-slate-700 rounded-[5px] px-2.5 py-2 text-slate-200 font-mono text-xs outline-none w-full transition-colors focus:border-blue-500';
-  const labelCls = 'text-[9px] text-slate-500 uppercase tracking-wider mb-1 font-mono font-semibold';
+    'bg-disk-bg border border-disk-border rounded-lg px-2.5 py-2 text-white text-[13px] outline-none w-full transition-all focus:border-disk-accent focus:ring-1 focus:ring-[#0a84ff]/20';
+  const labelCls = 'text-[11px] text-[#8e8e9d] uppercase tracking-wider mb-1.5 font-medium';
 
   return (
-    <div className="bg-disk-surface rounded-[10px] p-5 mb-4 border border-disk-border">
-      <div className="text-[10px] text-slate-400 font-mono font-semibold uppercase tracking-wider mb-3.5">
+    <div className="bg-disk-surface rounded-xl p-5 mb-4 border border-disk-border">
+      <div className="text-[11px] text-[#8e8e9d] font-semibold uppercase tracking-widest mb-4">
         ⛁ Disk Configuration
       </div>
 
       <div className="grid grid-cols-[2fr_1fr_1fr] gap-3">
-        {/* Disk size */}
         <div>
           <div className={labelCls}>Disk Size</div>
           <div className="flex gap-1.5">
@@ -51,7 +47,6 @@ export default function DiskConfig({
           </div>
         </div>
 
-        {/* Sector size */}
         <div>
           <div className={labelCls}>Sector Size</div>
           <select
@@ -65,23 +60,21 @@ export default function DiskConfig({
           </select>
         </div>
 
-        {/* Total blocks */}
         <div>
           <div className={labelCls}>Total Blocks (LBA)</div>
           <input
             value={totalBlocks}
             onChange={(e) => setTotalBlocks(e.target.value)}
-            className={inputCls + ' font-bold text-blue-400'}
+            className={inputCls + ' font-mono font-bold text-disk-accent'}
             placeholder="0"
           />
         </div>
       </div>
 
-      {/* Stats row */}
-      <div className="flex gap-4 mt-3.5 flex-wrap text-[10px] font-mono">
-        <Stat label="Disk Size" value={formatSize(diskBytes)} color="#F8FAFC" />
-        <Stat label="Allocated" value={`${formatBlocks(allocatedBlocks)} blocks`} color="#10B981" />
-        <Stat label="Free" value={`${formatBlocks(freeBlocks)} blocks`} color="#F59E0B" />
+      <div className="flex gap-5 mt-4 flex-wrap text-[12px]">
+        <Stat label="Disk Size" value={formatSize(diskBytes)} color="#ffffff" />
+        <Stat label="Allocated" value={`${formatBlocks(allocatedBlocks)} blocks`} color="#30d158" />
+        <Stat label="Free" value={`${formatBlocks(freeBlocks)} blocks`} color="#ff9f0a" />
         <Stat
           label="Overlapping"
           value={
@@ -89,7 +82,7 @@ export default function DiskConfig({
               ? `${overlapBlocks.toLocaleString()} blocks (${overlaps.length} conflict${overlaps.length > 1 ? 's' : ''})`
               : 'None'
           }
-          color={overlaps.length > 0 ? '#DC2626' : '#475569'}
+          color={overlaps.length > 0 ? '#ff453a' : '#48484a'}
         />
       </div>
     </div>
@@ -99,8 +92,8 @@ export default function DiskConfig({
 function Stat({ label, value, color }) {
   return (
     <div>
-      <span className="text-slate-500">{label}: </span>
-      <span className="font-semibold" style={{ color }}>{value}</span>
+      <span className="text-[#636366]">{label}: </span>
+      <span className="font-mono font-semibold" style={{ color }}>{value}</span>
     </div>
   );
 }

--- a/src/components/Legend.jsx
+++ b/src/components/Legend.jsx
@@ -1,32 +1,29 @@
 import { UNALLOC_COLOR } from '../utils';
 
-/**
- * Color legend showing partition names and percentages.
- */
 export default function Legend({ segments, totalBlocks }) {
   const allocated = segments.filter((s) => s.type !== 'unallocated');
 
   return (
-    <div className="mt-2.5 w-full">
+    <div className="mt-3 w-full">
       {allocated.map((s, i) => (
-        <div key={i} className="flex items-center gap-1.5 mb-1 text-[9px] font-mono">
+        <div key={i} className="flex items-center gap-2 mb-1.5 text-[12px]">
           <div className="w-2 h-2 rounded-sm shrink-0" style={{ background: s.color }} />
-          <span className="text-slate-400 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+          <span className="text-[#ebebf5] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
             {s.label}
           </span>
-          <span className="text-slate-500">
+          <span className="text-[#636366] font-mono text-[11px]">
             {((s.blocks / totalBlocks) * 100).toFixed(1)}%
           </span>
         </div>
       ))}
-      <div className="flex items-center gap-1.5 text-[9px] font-mono mt-0.5">
+      <div className="flex items-center gap-2 text-[12px] mt-1">
         <div
           className="w-2 h-2 rounded-sm shrink-0"
           style={{
-            background: `repeating-linear-gradient(135deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 2px, #1a2940 2px, #1a2940 4px)`,
+            background: `repeating-linear-gradient(135deg, ${UNALLOC_COLOR} 0px, ${UNALLOC_COLOR} 2px, #2c2c2e 2px, #2c2c2e 4px)`,
           }}
         />
-        <span className="text-slate-600">Unallocated</span>
+        <span className="text-[#48484a]">Unallocated</span>
       </div>
     </div>
   );

--- a/src/components/PartitionForm.jsx
+++ b/src/components/PartitionForm.jsx
@@ -1,10 +1,6 @@
 import { useState, useEffect } from 'react';
 import { PARTITION_COLORS, OVERLAP_COLOR } from '../utils';
 
-/**
- * Form for creating or editing a partition.
- * Shows overlap warnings when conflicts exist.
- */
 export default function PartitionForm({
   partitions,
   overlaps,
@@ -18,7 +14,6 @@ export default function PartitionForm({
   const [startBlock, setStartBlock] = useState('');
   const [endBlock, setEndBlock] = useState('');
 
-  // Populate fields when editing
   useEffect(() => {
     if (editIdx !== null && partitions[editIdx]) {
       const p = partitions[editIdx];
@@ -60,28 +55,27 @@ export default function PartitionForm({
   };
 
   const inputCls =
-    'bg-[#0F172A] border border-slate-700 rounded-[5px] px-2.5 py-2 text-slate-200 font-mono text-xs outline-none w-full transition-colors focus:border-blue-500';
+    'bg-disk-bg border border-disk-border rounded-lg px-2.5 py-2 text-white text-[13px] outline-none w-full transition-all focus:border-disk-accent focus:ring-1 focus:ring-[#0a84ff]/20';
+  const labelCls = 'text-[11px] text-[#8e8e9d] uppercase tracking-wider mb-1.5 font-medium block';
 
   const isEditing = editIdx !== null;
-  const borderColor = isEditing ? PARTITION_COLORS[editIdx % PARTITION_COLORS.length] + '44' : undefined;
+  const accentColor = isEditing ? PARTITION_COLORS[editIdx % PARTITION_COLORS.length] : '#0a84ff';
 
   return (
     <div
-      className="bg-disk-surface rounded-[10px] p-5 border"
-      style={{ borderColor: borderColor || '#1E293B' }}
+      className="bg-disk-surface rounded-xl p-5 border"
+      style={{ borderColor: isEditing ? accentColor + '44' : '#3a3a3c' }}
     >
       <div
-        className="text-[10px] font-mono font-semibold uppercase tracking-wider mb-3.5"
-        style={{ color: isEditing ? PARTITION_COLORS[editIdx % PARTITION_COLORS.length] : '#94A3B8' }}
+        className="text-[11px] font-semibold uppercase tracking-widest mb-4"
+        style={{ color: isEditing ? accentColor : '#8e8e9d' }}
       >
-        {isEditing ? `✎ Editing: ${partitions[editIdx]?.name}` : '＋ Create Partition'}
+        {isEditing ? `✎ Editing: ${partitions[editIdx]?.name}` : '＋ Add Partition'}
       </div>
 
       <div className="grid grid-cols-[2fr_1fr_1fr_auto] gap-3 items-end">
         <div>
-          <label className="text-[9px] text-slate-500 uppercase tracking-wider mb-1 font-mono font-semibold block">
-            Name
-          </label>
+          <label className={labelCls}>Name</label>
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
@@ -91,9 +85,7 @@ export default function PartitionForm({
           />
         </div>
         <div>
-          <label className="text-[9px] text-slate-500 uppercase tracking-wider mb-1 font-mono font-semibold block">
-            Start Block (LBA)
-          </label>
+          <label className={labelCls}>Start Block (LBA)</label>
           <input
             value={startBlock}
             onChange={(e) => setStartBlock(e.target.value)}
@@ -101,13 +93,11 @@ export default function PartitionForm({
             placeholder="0"
             type="number"
             min="0"
-            className={inputCls}
+            className={inputCls + ' font-mono'}
           />
         </div>
         <div>
-          <label className="text-[9px] text-slate-500 uppercase tracking-wider mb-1 font-mono font-semibold block">
-            End Block (LBA)
-          </label>
+          <label className={labelCls}>End Block (LBA)</label>
           <input
             value={endBlock}
             onChange={(e) => setEndBlock(e.target.value)}
@@ -115,20 +105,21 @@ export default function PartitionForm({
             placeholder={totalBlocks > 0 ? (totalBlocks - 1).toString() : '999999'}
             type="number"
             min="0"
-            className={inputCls}
+            className={inputCls + ' font-mono'}
           />
         </div>
         <div className="flex gap-2">
           <button
             onClick={handleSubmit}
-            className="bg-gradient-to-br from-blue-500 to-indigo-500 border-none rounded-md text-white px-4 py-2 cursor-pointer font-bold text-[11px] font-mono tracking-wide shadow-lg shadow-blue-500/25 hover:shadow-blue-500/40 transition-shadow"
+            className="rounded-lg text-white px-4 py-2 cursor-pointer font-semibold text-[13px] transition-colors"
+            style={{ background: accentColor }}
           >
-            {isEditing ? 'UPDATE' : 'ADD'}
+            {isEditing ? 'Update' : 'Add'}
           </button>
           {isEditing && (
             <button
               onClick={handleCancel}
-              className="bg-transparent border border-slate-700 rounded-md text-slate-400 px-3.5 py-2 cursor-pointer text-[11px] font-mono hover:border-slate-500 transition-colors"
+              className="bg-transparent border border-disk-border rounded-lg text-[#8e8e9d] px-3.5 py-2 cursor-pointer text-[13px] hover:border-disk-border-light transition-colors"
             >
               Cancel
             </button>
@@ -136,14 +127,13 @@ export default function PartitionForm({
         </div>
       </div>
 
-      {/* Overlap warnings */}
       {overlaps.length > 0 && (
-        <div className="mt-3.5 p-2.5 rounded-md bg-red-600/[0.07] border border-red-600/20">
-          <div className="text-[10px] font-bold mb-1" style={{ color: OVERLAP_COLOR }}>
+        <div className="mt-4 p-3 rounded-lg bg-[#ff453a]/10 border border-[#ff453a]/25">
+          <div className="text-[12px] font-semibold mb-1.5" style={{ color: OVERLAP_COLOR }}>
             ⚠ Partition Overlap Detected
           </div>
           {overlaps.map((o, i) => (
-            <div key={i} className="text-[9px] text-red-300 mb-0.5 font-mono">
+            <div key={i} className="text-[11px] text-[#ff6961] mb-0.5 font-mono">
               <strong>{partitions[o.i]?.name}</strong> ∩ <strong>{partitions[o.j]?.name}</strong>
               {' — blocks '}
               {o.start.toLocaleString()} to {o.end.toLocaleString()} (

--- a/src/components/PartitionTable.jsx
+++ b/src/components/PartitionTable.jsx
@@ -1,9 +1,5 @@
 import { PARTITION_COLORS, OVERLAP_COLOR, formatBlocks, formatSize } from '../utils';
 
-/**
- * Detailed table of all partitions with LBA ranges, size, percentage, and
- * overlap indicators. Each partition can be edited or removed.
- */
 export default function PartitionTable({
   partitions,
   totalBlocks,
@@ -23,7 +19,7 @@ export default function PartitionTable({
         return (
           <div
             key={i}
-            className="flex items-center gap-2.5 py-1.5 border-b border-disk-border"
+            className="flex items-center gap-3 py-2 border-b border-disk-border"
           >
             <div
               className="w-2.5 h-2.5 rounded-sm shrink-0"
@@ -31,18 +27,18 @@ export default function PartitionTable({
             />
 
             <div className="flex-1 min-w-0">
-              <div className="text-[11px] font-semibold text-slate-200 flex items-center gap-1.5">
+              <div className="text-[13px] font-semibold text-white flex items-center gap-1.5">
                 {p.name}
                 {hasOverlap && (
                   <span
-                    className="text-[8px] rounded-sm px-1.5 py-px"
-                    style={{ color: OVERLAP_COLOR, background: '#DC262622' }}
+                    className="text-[9px] rounded px-1.5 py-px font-medium"
+                    style={{ color: OVERLAP_COLOR, background: '#ff453a22' }}
                   >
                     OVERLAP
                   </span>
                 )}
               </div>
-              <div className="text-[9px] text-slate-500 font-mono">
+              <div className="text-[11px] text-[#8e8e9d] font-mono mt-0.5">
                 LBA {p.startBlock.toLocaleString()} → {p.endBlock.toLocaleString()} ·{' '}
                 {formatBlocks(blocks)} blocks · {pct.toFixed(2)}% ·{' '}
                 {formatSize(blocks * sectorSize)}
@@ -51,13 +47,13 @@ export default function PartitionTable({
 
             <button
               onClick={() => onEdit(i)}
-              className="bg-transparent border border-slate-700 rounded px-2 py-0.5 text-slate-500 text-[9px] font-mono cursor-pointer hover:border-blue-500 hover:text-slate-300 transition-colors"
+              className="bg-transparent border border-disk-border rounded-md px-2.5 py-1 text-[#8e8e9d] text-[11px] cursor-pointer hover:border-disk-accent hover:text-white transition-colors"
             >
               Edit
             </button>
             <button
               onClick={() => onRemove(i)}
-              className="bg-transparent border border-slate-700 rounded px-2 py-0.5 text-red-500 text-[9px] font-mono cursor-pointer hover:border-red-500 hover:text-red-400 transition-colors"
+              className="bg-transparent border border-disk-border rounded-md px-2.5 py-1 text-[#ff453a] text-[11px] cursor-pointer hover:border-[#ff453a]/60 hover:bg-[#ff453a]/10 transition-colors"
             >
               ×
             </button>
@@ -66,7 +62,7 @@ export default function PartitionTable({
       })}
 
       {partitions.length === 0 && (
-        <div className="text-center py-6 text-slate-600 text-xs font-mono">
+        <div className="text-center py-8 text-[#48484a] text-[13px]">
           No partitions defined. Add one below or load a preset.
         </div>
       )}

--- a/src/components/PieChart.jsx
+++ b/src/components/PieChart.jsx
@@ -2,10 +2,9 @@ import { useState } from 'react';
 import { UNALLOC_COLOR } from '../utils';
 import { formatBlocks } from '../utils';
 
-/**
- * Donut-style pie chart showing partition allocation proportions.
- * Hover a segment to see details in the center.
- */
+const FONT_UI = "-apple-system, 'SF Pro Text', system-ui, sans-serif";
+const FONT_MONO = "'SF Mono', 'IBM Plex Mono', ui-monospace, monospace";
+
 export default function PieChart({ segments, totalBlocks }) {
   const cx = 140;
   const cy = 140;
@@ -19,18 +18,17 @@ export default function PieChart({ segments, totalBlocks }) {
     return (
       <svg width={280} height={280} viewBox="0 0 280 280" role="img" aria-label="Empty disk — 100% unallocated">
         <circle cx={cx} cy={cy} r={r} fill={UNALLOC_COLOR} />
-        <circle cx={cx} cy={cy} r={ir} fill="#0F172A" />
-        <text x={cx} y={cy - 6} textAnchor="middle" fill="#64748B" fontSize="11" fontFamily="'IBM Plex Mono', monospace">
+        <circle cx={cx} cy={cy} r={ir} fill="#1c1c1e" />
+        <text x={cx} y={cy - 6} textAnchor="middle" fill="#636366" fontSize="13" fontFamily={FONT_MONO} fontWeight="500">
           100%
         </text>
-        <text x={cx} y={cy + 10} textAnchor="middle" fill="#475569" fontSize="9" fontFamily="'IBM Plex Mono', monospace">
+        <text x={cx} y={cy + 11} textAnchor="middle" fill="#48484a" fontSize="10" fontFamily={FONT_UI} letterSpacing="0.08em">
           UNALLOCATED
         </text>
       </svg>
     );
   }
 
-  // Build arc paths
   const paths = [];
   let angle = -Math.PI / 2;
 
@@ -57,13 +55,13 @@ export default function PieChart({ segments, totalBlocks }) {
         key={i}
         d={`M ${x1o} ${y1o} A ${r} ${r} 0 ${largeArc} 1 ${x2o} ${y2o} L ${x1i} ${y1i} A ${ir} ${ir} 0 ${largeArc} 0 ${x2i} ${y2i} Z`}
         fill={seg.color}
-        opacity={hovered !== null && !isHov ? 0.5 : 1}
+        opacity={hovered !== null && !isHov ? 0.45 : 1}
         style={{
           transform: isHov ? 'scale(1.04)' : 'scale(1)',
           transformOrigin: `${cx}px ${cy}px`,
           transition: 'all 0.2s ease',
           cursor: 'pointer',
-          filter: isHov ? `drop-shadow(0 0 8px ${seg.color}88)` : 'none',
+          filter: isHov ? `drop-shadow(0 0 10px ${seg.color}99)` : 'none',
         }}
         onMouseEnter={() => setHovered(i)}
         onMouseLeave={() => setHovered(null)}
@@ -77,25 +75,25 @@ export default function PieChart({ segments, totalBlocks }) {
   return (
     <svg width={280} height={280} viewBox="0 0 280 280" role="img" aria-label="Disk allocation pie chart">
       {paths}
-      <circle cx={cx} cy={cy} r={ir - 1} fill="#0F172A" />
+      <circle cx={cx} cy={cy} r={ir - 1} fill="#1c1c1e" />
       {hovSeg ? (
         <>
-          <text x={cx} y={cy - 10} textAnchor="middle" fill="#F8FAFC" fontSize="11" fontWeight="600" fontFamily="'IBM Plex Mono', monospace">
+          <text x={cx} y={cy - 10} textAnchor="middle" fill="#ffffff" fontSize="12" fontWeight="600" fontFamily={FONT_UI}>
             {hovSeg.label}
           </text>
-          <text x={cx} y={cy + 6} textAnchor="middle" fill="#94A3B8" fontSize="9" fontFamily="'IBM Plex Mono', monospace">
+          <text x={cx} y={cy + 7} textAnchor="middle" fill="#8e8e9d" fontSize="11" fontFamily={FONT_MONO}>
             {((hovSeg.blocks / totalBlocks) * 100).toFixed(1)}%
           </text>
-          <text x={cx} y={cy + 20} textAnchor="middle" fill="#64748B" fontSize="8" fontFamily="'IBM Plex Mono', monospace">
+          <text x={cx} y={cy + 22} textAnchor="middle" fill="#636366" fontSize="9" fontFamily={FONT_MONO}>
             {formatBlocks(hovSeg.blocks)} blocks
           </text>
         </>
       ) : (
         <>
-          <text x={cx} y={cy - 4} textAnchor="middle" fill="#94A3B8" fontSize="10" fontFamily="'IBM Plex Mono', monospace">
+          <text x={cx} y={cy - 5} textAnchor="middle" fill="#636366" fontSize="10" fontFamily={FONT_UI} letterSpacing="0.08em">
             TOTAL
           </text>
-          <text x={cx} y={cy + 12} textAnchor="middle" fill="#F8FAFC" fontSize="12" fontWeight="700" fontFamily="'IBM Plex Mono', monospace">
+          <text x={cx} y={cy + 13} textAnchor="middle" fill="#ffffff" fontSize="13" fontWeight="700" fontFamily={FONT_MONO}>
             {formatBlocks(totalBlocks)}
           </text>
         </>

--- a/src/components/PresetBar.jsx
+++ b/src/components/PresetBar.jsx
@@ -1,18 +1,15 @@
 import PRESETS from '../presets';
 
-/**
- * Row of clickable preset buttons for common disk layouts.
- */
 export default function PresetBar({ onLoad }) {
   return (
-    <div className="flex gap-2 mt-3.5 flex-wrap items-center">
-      <span className="text-[9px] text-slate-600 font-mono">Quick presets:</span>
+    <div className="flex gap-2 mt-4 flex-wrap items-center">
+      <span className="text-[11px] text-[#636366]">Quick presets:</span>
       {PRESETS.map((preset) => (
         <button
           key={preset.id}
           onClick={() => onLoad(preset)}
           title={preset.description}
-          className="bg-disk-border border border-slate-700 rounded-[5px] text-slate-400 px-3 py-1 cursor-pointer text-[10px] font-mono transition-colors hover:border-blue-500 hover:text-slate-200"
+          className="bg-disk-surface border border-disk-border rounded-lg text-[#8e8e9d] px-3 py-1.5 cursor-pointer text-[11px] font-medium transition-all hover:border-disk-accent hover:text-white"
         >
           {preset.label}
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -10,9 +10,9 @@
 
 body {
   margin: 0;
-  background: #0b1120;
-  color: #e2e8f0;
-  font-family: 'IBM Plex Mono', ui-monospace, monospace;
+  background: #1c1c1e;
+  color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Helvetica Neue', system-ui, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -21,14 +21,14 @@ body {
   width: 6px;
 }
 ::-webkit-scrollbar-track {
-  background: #0b1120;
+  background: #1c1c1e;
 }
 ::-webkit-scrollbar-thumb {
-  background: #334155;
+  background: #48484a;
   border-radius: 3px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #475569;
+  background: #636366;
 }
 
 /* Number input spinners — hide in Webkit */

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,13 +2,25 @@
  * Partition color palette. Each partition gets a color by index mod length.
  */
 export const PARTITION_COLORS = [
-  '#3B82F6', '#10B981', '#F59E0B', '#EF4444', '#8B5CF6',
-  '#EC4899', '#06B6D4', '#F97316', '#6366F1', '#14B8A6',
-  '#E11D48', '#7C3AED', '#0EA5E9', '#D946EF', '#84CC16',
+  '#0a84ff', // Blue
+  '#30d158', // Green
+  '#ff9f0a', // Orange
+  '#bf5af2', // Purple
+  '#ff453a', // Red
+  '#64d2ff', // Cyan
+  '#ffd60a', // Yellow
+  '#5e5ce6', // Indigo
+  '#ff375f', // Pink
+  '#32ade6', // Teal
+  '#ac8e68', // Brown
+  '#63e6e2', // Mint
+  '#ff6961', // Salmon
+  '#b4d455', // Lime
+  '#ff9500', // Amber
 ];
 
-export const UNALLOC_COLOR = '#1E293B';
-export const OVERLAP_COLOR = '#DC2626';
+export const UNALLOC_COLOR = '#3a3a3c';
+export const OVERLAP_COLOR = '#ff453a';
 
 /**
  * Available sector sizes in bytes.

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,17 +5,19 @@ export default {
     extend: {
       colors: {
         disk: {
-          bg: '#0B1120',
-          surface: '#111827',
-          border: '#1E293B',
-          'border-light': '#334155',
-          unalloc: '#1E293B',
-          overlap: '#DC2626',
+          bg: '#1c1c1e',
+          surface: '#2c2c2e',
+          border: '#3a3a3c',
+          'border-light': '#48484a',
+          unalloc: '#3a3a3c',
+          overlap: '#ff453a',
+          accent: '#0a84ff',
         },
       },
       fontFamily: {
-        mono: ['"IBM Plex Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
-        display: ['"Space Grotesk"', 'system-ui', 'sans-serif'],
+        sans: ['-apple-system', 'BlinkMacSystemFont', '"SF Pro Text"', '"Helvetica Neue"', 'system-ui', 'sans-serif'],
+        mono: ['"SF Mono"', '"IBM Plex Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+        display: ['"Space Grotesk"', '-apple-system', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes #20

- Updated color palette to macOS/iOS system colors (e.g. `#ff453a` for destructive actions, `#8e8e9d` for secondary text)
- Consistent rounded corners (`rounded-xl`, `rounded-2xl`) and refined spacing throughout
- Backdrop blur + darker overlay on modal dialogs for a native feel
- Improved typographic scale — dropped `font-mono` from UI chrome, better tracking and sizing
- Tweaked panel headers, button styles, and section labels for clearer visual hierarchy
- Cleaned up redundant inline comments in JSX

## Test plan

- [ ] Spin up dev server (`npm run dev`) and visually verify all panels look correct
- [ ] Confirm Reset dialog renders with blur overlay and correct button colors
- [ ] Check Pie Chart, Disk Bar, Partition Form, and Table for consistent styling
- [ ] Run `npm test` to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)