### PR TITLE
Add custom presets and fix partition form default values

### DIFF
--- a/src/components/PartitionForm.jsx
+++ b/src/components/PartitionForm.jsx
@@ -11,8 +11,10 @@ export default function PartitionForm({
   setEditIdx,
 }) {
   const [name, setName] = useState('');
-  const [startBlock, setStartBlock] = useState('');
-  const [endBlock, setEndBlock] = useState('');
+  const [startBlock, setStartBlock] = useState('0');
+  const [endBlock, setEndBlock] = useState(() =>
+    totalBlocks > 0 ? (totalBlocks - 1).toString() : '999999'
+  );
 
   useEffect(() => {
     if (editIdx !== null && partitions[editIdx]) {
@@ -38,15 +40,15 @@ export default function PartitionForm({
       onAdd(partition);
     }
     setName('');
-    setStartBlock('');
-    setEndBlock('');
+    setStartBlock('0');
+    setEndBlock(totalBlocks > 0 ? (totalBlocks - 1).toString() : '999999');
   };
 
   const handleCancel = () => {
     setEditIdx(null);
     setName('');
-    setStartBlock('');
-    setEndBlock('');
+    setStartBlock('0');
+    setEndBlock(totalBlocks > 0 ? (totalBlocks - 1).toString() : '999999');
   };
 
   const handleKeyDown = (e) => {

--- a/src/test/PartitionForm.test.jsx
+++ b/src/test/PartitionForm.test.jsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PartitionForm from '../components/PartitionForm';
+
+const TOTAL_BLOCKS = 1000;
+
+function renderForm(props = {}) {
+  return render(
+    <PartitionForm
+      partitions={[]}
+      overlaps={[]}
+      totalBlocks={TOTAL_BLOCKS}
+      onAdd={vi.fn()}
+      onUpdate={vi.fn()}
+      editIdx={null}
+      setEditIdx={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+describe('PartitionForm — default values', () => {
+  it('pre-fills startBlock with 0', () => {
+    renderForm();
+    const [startInput] = screen.getAllByRole('spinbutton');
+    expect(startInput.value).toBe('0');
+  });
+
+  it('pre-fills endBlock with totalBlocks - 1', () => {
+    renderForm();
+    const [, endInput] = screen.getAllByRole('spinbutton');
+    expect(endInput.value).toBe('999');
+  });
+
+  it('pre-fills endBlock with 999999 when totalBlocks is 0', () => {
+    renderForm({ totalBlocks: 0 });
+    const [, endInput] = screen.getAllByRole('spinbutton');
+    expect(endInput.value).toBe('999999');
+  });
+});
+
+describe('PartitionForm — submitting with default values', () => {
+  it('calls onAdd with default values when Add is clicked without typing', () => {
+    const onAdd = vi.fn();
+    renderForm({ onAdd });
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAdd).toHaveBeenCalledOnce();
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Partition 1', startBlock: 0, endBlock: 999 });
+  });
+
+  it('uses 999999 as default endBlock when totalBlocks is 0', () => {
+    const onAdd = vi.fn();
+    renderForm({ onAdd, totalBlocks: 0 });
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Partition 1', startBlock: 0, endBlock: 999999 });
+  });
+
+  it('resets to default values after adding a partition', () => {
+    const onAdd = vi.fn();
+    renderForm({ onAdd });
+    const [startInput, endInput] = screen.getAllByRole('spinbutton');
+    fireEvent.change(startInput, { target: { value: '100' } });
+    fireEvent.change(endInput, { target: { value: '200' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(startInput.value).toBe('0');
+    expect(endInput.value).toBe('999');
+  });
+
+  it('respects manually entered values over defaults', () => {
+    const onAdd = vi.fn();
+    renderForm({ onAdd });
+    const [startInput, endInput] = screen.getAllByRole('spinbutton');
+    fireEvent.change(startInput, { target: { value: '100' } });
+    fireEvent.change(endInput, { target: { value: '500' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAdd).toHaveBeenCalledWith({ name: 'Partition 1', startBlock: 100, endBlock: 500 });
+  });
+});
+
+describe('PartitionForm — validation', () => {
+  it('does not call onAdd when end < start', () => {
+    const onAdd = vi.fn();
+    renderForm({ onAdd });
+    const [startInput, endInput] = screen.getAllByRole('spinbutton');
+    fireEvent.change(startInput, { target: { value: '500' } });
+    fireEvent.change(endInput, { target: { value: '100' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('does not call onAdd when start is negative', () => {
+    const onAdd = vi.fn();
+    renderForm({ onAdd });
+    const [startInput] = screen.getAllByRole('spinbutton');
+    fireEvent.change(startInput, { target: { value: '-1' } });
+    fireEvent.click(screen.getByText('Add'));
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+});
+
+describe('PartitionForm — editing', () => {
+  it('loads partition values into form when editIdx is set', () => {
+    const partitions = [{ name: 'Root', startBlock: 10, endBlock: 500 }];
+    renderForm({ partitions, editIdx: 0 });
+    const [startInput, endInput] = screen.getAllByRole('spinbutton');
+    expect(startInput.value).toBe('10');
+    expect(endInput.value).toBe('500');
+  });
+
+  it('calls onUpdate with edited values', () => {
+    const partitions = [{ name: 'Root', startBlock: 10, endBlock: 500 }];
+    const onUpdate = vi.fn();
+    const setEditIdx = vi.fn();
+    renderForm({ partitions, editIdx: 0, onUpdate, setEditIdx });
+    fireEvent.click(screen.getByText('Update'));
+    expect(onUpdate).toHaveBeenCalledWith(0, { name: 'Root', startBlock: 10, endBlock: 500 });
+  });
+
+  it('resets to defaults on cancel', () => {
+    const partitions = [{ name: 'Root', startBlock: 10, endBlock: 500 }];
+    const setEditIdx = vi.fn();
+    renderForm({ partitions, editIdx: 0, setEditIdx });
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(setEditIdx).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds custom user presets — save, load, and delete named partition layouts
- Fixes the Add Partition form ignoring placeholder defaults on submit (closes #25): start/end block fields now initialize with real values (`0` and `totalBlocks - 1`) so clicking **Add** without typing works as expected
- Adds `PartitionForm` test suite (12 tests)

## Test plan

- [ ] Save a preset, reload the page, verify it persists
- [ ] Load a saved preset and confirm partitions are applied
- [ ] Delete a preset and confirm it's removed
- [ ] Click **Add** on the partition form without typing — should create a partition with start=0 and end=totalBlocks-1
- [ ] `npm test` — all 81 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)